### PR TITLE
Fix beam search alphabet duplicates

### DIFF
--- a/app_V2.py
+++ b/app_V2.py
@@ -732,8 +732,10 @@ class MainWindow(QMainWindow):
     def _loadCognitionClassifier(self):
         cfg = self.cfg.get("cognition", {})       # add this block to config.json later
         try:
+            base_dir = Path(__file__).resolve().parent
+            default_pkl = base_dir / "cognition_training" / "classifier.pkl"
             self.cogCls = CognitionClassifier(
-                model_pkl      = Path(cfg.get("model_pkl",  "cognition_training/classifier.pkl")),
+                model_pkl      = Path(cfg.get("model_pkl",  str(default_pkl))),
                 dict_dir       = Path(cfg.get("dict_dir",   "dicts")),
                 processor_path = cfg.get("pretrained_processor", self.cfg["pretrained_processor"]),
                 asr_model_path = cfg.get("pretrained_model",     self.cfg["pretrained_model"]),

--- a/src/asaca/inference.py
+++ b/src/asaca/inference.py
@@ -407,10 +407,12 @@ def decode_text(
 
     try:
         return ctc_decoder.beam_search(probs, chars, **kwargs)
-    except IndexError as e:  # mis-match safety-net
+    except (IndexError, ValueError) as e:  # mis-match or invalid alphabet
         # fallback to best-path to avoid crash
-        debug_print(f"[decode_text] Beam-search failed ({e}); "
-                    f"falling back to best_path.")
+        debug_print(
+            f"[decode_text] Beam-search failed ({e}); "
+            f"falling back to best_path."
+        )
         return ctc_decoder.best_path(probs, chars)
 
 

--- a/src/pyctcdecoder/__init__.py
+++ b/src/pyctcdecoder/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import Optional
+from typing import Dict, Optional
 
 import numpy as np
 from pyctcdecode import BeamSearchDecoderCTC, build_ctcdecoder
@@ -9,15 +9,43 @@ from pyctcdecode import BeamSearchDecoderCTC, build_ctcdecoder
 
 @lru_cache(maxsize=None)
 def _get_decoder(chars: str, lm_text: Optional[str]) -> BeamSearchDecoderCTC:
-    labels = list(chars)
+    """Return a cached decoder with a unique alphabet for ``chars``.
+
+    ``pyctcdecode`` does not allow duplicate labels. Some tokenizers map
+    multiple IDs to the same character (e.g. special tokens like ``<pad>``
+    and ``</s>``).  We assign temporary surrogate characters from the
+    Unicode Private Use Area for duplicates so the decoder can be built
+    reliably and keep a reverse mapping for later.
+    """
+
+    labels: list[str] = []
+    mapping: Dict[str, str] = {}
+    used = set()
+    next_private = 0xE000
+    for ch in chars:
+        if ch in used:
+            surrogate = chr(next_private)
+            next_private += 1
+        else:
+            surrogate = ch
+            used.add(ch)
+        labels.append(surrogate)
+        mapping[surrogate] = ch
+
     unigrams = list(lm_text) if lm_text else None
-    return build_ctcdecoder(labels, kenlm_model_path=None, unigrams=unigrams)
+    decoder = build_ctcdecoder(labels, kenlm_model_path=None, unigrams=unigrams)
+    decoder._char_mapping = mapping  # type: ignore[attr-defined]
+    return decoder
 
 
 def beam_search(mat: np.ndarray, chars: str, beam_width: int = 25, lm_text: Optional[str] = None) -> str:
-    """Beam search decoder using :mod:`pyctcdecode`."""
+    """Beam search decoder using :mod:`pyctcdecode` with de-duplicated labels."""
     decoder = _get_decoder(chars, lm_text)
-    return decoder.decode(mat, beam_width=beam_width)
+    res = decoder.decode(mat, beam_width=beam_width)
+    mapping: Dict[str, str] = getattr(decoder, "_char_mapping", {})  # type: ignore[attr-defined]
+    if mapping:
+        res = "".join(mapping.get(ch, ch) for ch in res)
+    return res
 
 
 def best_path(mat: np.ndarray, chars: str) -> str:


### PR DESCRIPTION
## Summary
- deduplicate decoder alphabet with private-use characters
- map decoded output back to original chars

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867ded4ec44832aac091ede6712e6ea