### PR TITLE
Replace pyctcdecoder with built‑in CTC decoder

### DIFF
--- a/inference_V4.py
+++ b/inference_V4.py
@@ -46,7 +46,7 @@ from jiwer import wer
 from scipy.signal import medfilt
 from transformers import Wav2Vec2Processor, Wav2Vec2ForCTC
 import ctc_segmentation as cs
-from pyctcdecoder import beam_search, best_path
+from ctc_decoder import beam_search, best_path
 import pandas as pd
 import inspect
 from types import SimpleNamespace
@@ -388,10 +388,9 @@ def decode_text(
     probs : np.ndarray [T,C]   (blank = last column!!)
     chars : str of length C-1  (blank excluded)
     decoder_method : "beam_search" | "best_path"
-    lm_text : optional str  → used only if the installed
-              `pyctcdecoder.beam_search` supports the arg.
+    lm_text : optional str  → ignored in the built-in decoder.
     """
-    import pyctcdecoder as ctc_decoder  # local import avoids hard dep at module import
+    import ctc_decoder  # local import avoids hard dep at module import
 
     if decoder_method == "best_path":
         return ctc_decoder.best_path(probs, chars)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "webrtcvad",
     "praat-parselmouth>=0.4",
     "pronouncing>=0.2",
-    "pyctcdecode>=0.5",
     "jiwer>=3.0",
     "pyannote.audio>=3.1",
     "pyannote.core>=5.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ ctc-segmentation>=1.7
 webrtcvad                  
 praat-parselmouth  
 pronouncing>=0.2            
-pyctcdecode>=0.5            
 jiwer>=3.0                   
 pyannote.audio>=3.1         
 pyannote.core>=5.0

--- a/src/asaca/inference.py
+++ b/src/asaca/inference.py
@@ -49,7 +49,7 @@ from jiwer import wer
 from scipy.signal import medfilt
 from transformers import Wav2Vec2Processor, Wav2Vec2ForCTC
 import ctc_segmentation as cs
-from pyctcdecoder import beam_search, best_path
+from ctc_decoder import beam_search, best_path
 import pandas as pd
 import inspect
 from types import SimpleNamespace
@@ -391,10 +391,9 @@ def decode_text(
     probs : np.ndarray [T,C]   (blank = last column!!)
     chars : str of length C-1  (blank excluded)
     decoder_method : "beam_search" | "best_path"
-    lm_text : optional str  → used only if the installed
-              `pyctcdecoder.beam_search` supports the arg.
+    lm_text : optional str  → ignored in the built-in decoder.
     """
-    import pyctcdecoder as ctc_decoder  # local import avoids hard dep at module import
+    import ctc_decoder  # local import avoids hard dep at module import
 
     if decoder_method == "best_path":
         return ctc_decoder.best_path(probs, chars)

--- a/src/ctc_decoder/__init__.py
+++ b/src/ctc_decoder/__init__.py
@@ -1,0 +1,63 @@
+import numpy as np
+from functools import lru_cache
+from typing import Optional, Dict, Tuple
+
+@lru_cache(maxsize=None)
+def _token_list(chars: str) -> Tuple[str, ...]:
+    return tuple(chars)
+
+
+def best_path(mat: np.ndarray, chars: str) -> str:
+    """Greedy CTC decoding (best path)."""
+    blank_idx = len(chars)
+    best_indices = np.argmax(mat, axis=1)
+    out = []
+    prev = None
+    for idx in best_indices:
+        if idx != prev and idx != blank_idx:
+            out.append(chars[idx])
+        prev = idx
+    return "".join(out)
+
+
+def beam_search(mat: np.ndarray, chars: str, beam_width: int = 25, lm_text: Optional[str] = None) -> str:
+    """Simple prefix beam search decoder.
+
+    Parameters
+    ----------
+    mat : ``np.ndarray`` of shape ``(T, C)`` where ``C = len(chars) + 1`` and the
+        last column is the blank probability.
+    chars : mapping from column index to character, length ``C-1``.
+    beam_width : number of beams to keep after each step.
+    lm_text : unused, present for API compatibility.
+    """
+    blank_id = len(chars)
+    char_list = list(chars)
+
+    beams: Dict[str, float] = {"": 0.0}
+    for t in range(mat.shape[0]):
+        next_beams: Dict[str, float] = {}
+        for prefix, score in beams.items():
+            for i, p in enumerate(mat[t]):
+                new_score = score + float(np.log(p + 1e-12))
+                if i == blank_id:
+                    next_beams[prefix] = np.logaddexp(next_beams.get(prefix, float('-inf')), new_score)
+                else:
+                    ch = char_list[i]
+                    if prefix and prefix[-1] == ch:
+                        # either extend with same char or stay
+                        stay_prefix = prefix
+                        next_beams[stay_prefix] = np.logaddexp(next_beams.get(stay_prefix, float('-inf')), new_score)
+                        new_prefix = prefix + ch
+                        next_beams[new_prefix] = np.logaddexp(next_beams.get(new_prefix, float('-inf')), new_score)
+                    else:
+                        new_prefix = prefix + ch
+                        next_beams[new_prefix] = np.logaddexp(next_beams.get(new_prefix, float('-inf')), new_score)
+        # prune
+        beams = dict(sorted(next_beams.items(), key=lambda x: x[1], reverse=True)[:beam_width])
+
+    if not beams:
+        return ""
+    best = max(beams.items(), key=lambda x: x[1])[0]
+    return best
+


### PR DESCRIPTION
## Summary
- remove dependency on `pyctcdecode`
- implement a small `ctc_decoder` package providing `beam_search` and `best_path`
- switch inference code to use the new decoder

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d439d99a8832a974f784eba7d9261